### PR TITLE
The usage documentation used a semicolon when declaring variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Simple and fast router for Connect
 
 ```js
 var
-	connectRoute = require('connect-route');
+	connectRoute = require('connect-route'),
 	connect = require('connect'),
 	app = connect();
 


### PR DESCRIPTION
The usage documentation used a semicolon when declaring variables in the head of the file. That will cause a syntax error.
