### PR TITLE
Support method chaining for handler registration.

### DIFF
--- a/lib/connect-route.js
+++ b/lib/connect-route.js
@@ -12,6 +12,7 @@
 				for (i = 0; i < arguments.length - 1; i++) {
 					this.add(method, arguments[i], arguments[arguments.length - 1]);
 				}
+				return this;
 			};
 		},
 


### PR DESCRIPTION
Return "this" from the registration method.

Suggested fix for the issue #10 .