### PR TITLE
Allow matching the rest of the path by "*path" parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-.git*
 node_modules
-test

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ app.use(connectRoute(function (router) {
 		res.end('home ' + req.params.id);
 	});
 
+	router.get('/home/*path', function (req, res, next) {
+		res.end('home ' + req.params.path.join('/'));
+	});
+
 	router.post('/home', function (req, res, next) {
 		res.end('POST to home');
 	});

--- a/lib/connect-route.js
+++ b/lib/connect-route.js
@@ -20,7 +20,7 @@
 		};
 
 	Router.prototype.add = function (method, route, handler) {
-		var	parts, current, i, length, name;
+		var	parts, current, i, length, name, prefix;
 
 		if (typeof handler !== 'function') { return; }
 		if (!this.routes[method]) { this.routes[method] = { childs: {}, handler: undefined, route: undefined }; }
@@ -34,7 +34,8 @@
 			current = this.routes[method];
 			for (i = 0, length = parts.length; i < length; i++) {
 				name = undefined;
-				if (parts[i].charAt(0) === ':') {
+				prefix = parts[i].charAt(0);
+				if (prefix === ':' || prefix === '*') {
 					name = parts[i].substr(1);
 					parts[i] = '*';
 				}
@@ -47,6 +48,10 @@
 				}
 				if (parts[i] === '*') {
 					current = current.childs[parts[i]][length];
+					if (prefix === '*') {
+						current.last = true;
+						break;
+					}
 				} else {
 					current = current.childs[parts[i]];
 				}
@@ -73,6 +78,13 @@
 						current = current.childs[parts[i]];
 						result.handler = current.handler;
 						result.route = current.route;
+					} else if (current.childs['*'] && current.childs['*'][i + 1] &&
+								current.childs['*'][i + 1].last) {
+						current = current.childs['*'][i + 1];
+						result.handler = current.handler;
+						result.route = current.route;
+						result.params[current.name] = parts.slice(i);
+						break;
 					} else if (current.childs['*'] && current.childs['*'][length]) {
 						current = current.childs['*'][length];
 						result.handler = current.handler;

--- a/package.json
+++ b/package.json
@@ -9,5 +9,12 @@
 		"type": "git",
 		"url": "git://github.com/baryshev/connect-route.git"
 	},
-	"engines" : { "node": ">= 0.4.0" }
+	"engines" : { "node": ">= 0.4.0" },
+	"scripts": {
+		"test": "mocha"
+	},
+	"devDependencies": {
+		"chai": "~4.0.2",
+		"mocha": "~3.4.2"
+	}
 }

--- a/test/routes.js
+++ b/test/routes.js
@@ -167,5 +167,32 @@ describe('Router', function () {
       expect(this.req.params.id).to.equal('test1');
       expect(this.req.params.type).to.equal('test2');
     });
+
+    it('matches the whole path as a parametrized part (/*path)', function () {
+      this.route = route(function (router) {
+        router.get('/*path', function (req, res, next) {});
+      });
+      this.serve('GET', '/test');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.path).to.deep.equal(['test']);
+    });
+
+    it('matches the rest of the path as a parametrized part (/start/*path)', function () {
+      this.route = route(function (router) {
+        router.get('/start/*path', function (req, res, next) {});
+      });
+      this.serve('GET', '/start/test');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.path).to.deep.equal(['test']);
+    });
+
+    it('returns the rest of the path parts split (/*path)', function () {
+      this.route = route(function (router) {
+        router.get('/*path', function (req, res, next) {});
+      });
+      this.serve('GET', '/test1/test2');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.path).to.deep.equal(['test1', 'test2']);
+    });
   });
 });

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const expect = require('chai').expect,
+      route = require('../index');
+
+describe('Router', function () {
+  // this.route - has to be initialized by calling route()
+  // this.serve - simulates a server call with the specificed URL
+  // this.req   - allows inspecting the request object
+  // this.next  - allows checking, if next() has been called
+  before(function () {
+    this.serve = function (method, url) {
+      var req = {
+            method: method,
+            url: url
+          },
+          next = function () {
+            next.called = true;
+          };
+      this.req = req;
+      next.called = false;
+      this.next = next;
+      this.route(req, {}, next);
+    };
+  });
+
+  describe('when matching the method', function () {
+    it('matches all usual methods', function () {
+      [
+        'GET', 'POST', 'PUT', 'HEAD', 'PATCH', 'DELETE', 'CONNECT',
+        'OPTIONS', 'TRACE', 'COPY', 'LOCK', 'MKCOL', 'MOVE', 'PROPFIND',
+        'PROPPATCH', 'UNLOCK', 'REPORT', 'MKACTIVITY', 'CHECKOUT', 'MERGE'
+      ].forEach(function (method) {
+        this.route = route(function (router) {
+          var route = router[method.toLowerCase()];
+          expect(route).to.be.a('function');
+          route.call(router, '/', function (req, res, next) {});
+        });
+        this.serve(method, '/');
+        expect(this.next.called).to.equal(false);
+      }, this);
+    });
+
+    it('does not match an invalid method', function () {
+      this.route = route(function (router) {
+        router.get('/', function (req, res, next) {});
+      });
+      this.serve('TEST', '/');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('matches an upper-case method', function () {
+      this.route = route(function (router) {
+        router.get('/', function (req, res, next) {});
+      });
+      this.serve('GET', '/');
+      expect(this.next.called).to.equal(false);
+    });
+
+    it('does not match a lower-case method', function () {
+      this.route = route(function (router) {
+        router.get('/', function (req, res, next) {});
+      });
+      this.serve('get', '/');
+      expect(this.next.called).to.equal(true);
+    });
+  });
+
+  describe('when matching the path', function () {
+    it('matches the root path (/) only', function () {
+      this.route = route(function (router) {
+        router.get('/', function (req, res, next) {});
+      });
+      this.serve('GET', '/');
+      expect(this.next.called).to.equal(false);
+    });
+
+    it('matches using case-sensitive string comparisons', function () {
+      this.route = route(function (router) {
+        router.get('/test', function (req, res, next) {});
+      });
+      this.serve('GET', '/TEST');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('matches a path with a single part (/test) only', function () {
+      this.route = route(function (router) {
+        router.get('/test', function (req, res, next) {});
+      });
+      this.serve('GET', '/test');
+      expect(this.next.called).to.equal(false);
+    });
+
+    it('matches a path with two parts (/test1/test2) only', function () {
+      this.route = route(function (router) {
+        router.get('/test1/test2', function (req, res, next) {});
+      });
+      this.serve('GET', '/test1/test2');
+      expect(this.next.called).to.equal(false);
+    });
+
+    it('does not match an extra part at the beginning of the path (/test)', function () {
+      this.route = route(function (router) {
+        router.get('/test', function (req, res, next) {});
+      });
+      this.serve('GET', '/start/test');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('does not match an extra part at the end of the path (/test)', function () {
+      this.route = route(function (router) {
+        router.get('/test', function (req, res, next) {});
+      });
+      this.serve('GET', '/test/end');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('does not match a missing part at the end of the path (/test1/test2)', function () {
+      this.route = route(function (router) {
+        router.get('/test1/test2', function (req, res, next) {});
+      });
+      this.serve('GET', '/test1');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('does not match a missing part at the beginning of the path (/test1/test2)', function () {
+      this.route = route(function (router) {
+        router.get('/test1/test2', function (req, res, next) {});
+      });
+      this.serve('GET', '/test2');
+      expect(this.next.called).to.equal(true);
+    });
+
+    it('matches a parametrized part at the path beginning (/:id)', function () {
+      this.route = route(function (router) {
+        router.get('/:id', function (req, res, next) {});
+      });
+      this.serve('GET', '/test');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.id).to.equal('test');
+    });
+
+    it('matches a parametrized part at the path end (/start/:id)', function () {
+      this.route = route(function (router) {
+        router.get('/start/:id', function (req, res, next) {});
+      });
+      this.serve('GET', '/start/test');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.id).to.equal('test');
+    });
+
+    it('matches a parametrized part in the middle of the path (/start/:id/end)', function () {
+      this.route = route(function (router) {
+        router.get('/start/:id/end', function (req, res, next) {});
+      });
+      this.serve('GET', '/start/test/end');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.id).to.equal('test');
+    });
+
+    it('matches two parametrized parts of the path (/:id/:type)', function () {
+      this.route = route(function (router) {
+        router.get('/:id/:type', function (req, res, next) {});
+      });
+      this.serve('GET', '/test1/test2');
+      expect(this.next.called).to.equal(false);
+      expect(this.req.params.id).to.equal('test1');
+      expect(this.req.params.type).to.equal('test2');
+    });
+  });
+});


### PR DESCRIPTION
This is the syntax used by Backbone.js, for example.

Suggested fix for the issue #14.