### PR TITLE
Allow passing multiple chained handlers for a single route

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ app.use(connectRoute(function (router) {
 	router.post('/home', function (req, res, next) {
 		res.end('POST to home');
 	});
+
+	function authenticate(req, res, next) {
+		if (authenticated(req)) {
+			next();
+		} else {
+			fail(res);
+		}
+	}
+
+	router.get('/secret', authenticate, function (req, res, next) {
+		res.end('secret');
+	});
 }));
 
 app.listen(3000);

--- a/lib/connect-route.js
+++ b/lib/connect-route.js
@@ -5,12 +5,43 @@
 		separator = /^[\s\/]+|[\s\/]+$/g,
 		i, length,
 
+		chainHandlers = function (chain) {
+			return function (request, response, next) {
+				var
+					handlers = chain.slice(),
+					handle = function () {
+						var handler = handlers.shift();
+						if (handler) {
+							handler(request, response, handle);
+						} else {
+							next();
+						}
+					};
+				handle();
+			};
+		},
+
 		createMethodHandler = function (method) {
 			method = method.toUpperCase();
 			return function () {
-				var i;
-				for (i = 0; i < arguments.length - 1; i++) {
-					this.add(method, arguments[i], arguments[arguments.length - 1]);
+				var
+					routes = [],
+					handlers = [],
+					i, j, handler;
+				for (i = 0; i < arguments.length; ++i) {
+					if (typeof arguments[i] === 'function') {
+						handlers.push(arguments[i]);
+					} else {
+						routes.push(arguments[i]);
+					}
+				}
+				for (i = 0; i < routes.length; ++i) {
+					if (handlers.length > 1) {
+						handler = chainHandlers(handlers);
+					} else {
+						handler = handlers[0];
+					}
+					this.add(method, routes[i], handler);
 				}
 				return this;
 			};


### PR DESCRIPTION
Allow writing shared handlers, which process a part of the request and
let the next handler continue, or stop processing by not calling nex().

This aims to fix #17.